### PR TITLE
Update index.js

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -47,7 +47,7 @@ const Home = () => {
 			parentHandshake.emit('init', true);
 		} catch (err) {
 			// If error, set initial properties
-			setPaymentProps(initialProps);
+			//setPaymentProps(initialProps);
 		}
 	};
 


### PR DESCRIPTION
the error was being thrown that 'parentHandshake.emit is not a function'.
the comment says its on dev mode but i got this error when using 'npm run dev' or 'npm run start' and opening from the demo page.
so try without resetting back to the default props